### PR TITLE
Remove exeSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "put.io-v2": "git://github.com/343max/put.io.js-v2.git",
     "argv": "*",
     "underscore": "*",
-    "execSync": "*",
     "node-pushover": "*"
   }
 }

--- a/sync.js
+++ b/sync.js
@@ -114,7 +114,7 @@ function listDir(directoryId, localPath, isChildDir) {
         var files = [];
         _.each(data.files, function eachFile(fileNode) {
           if (fileNode.content_type == 'application/x-directory') {
-            listDir(fileNode.id, localFilePath, true);
+            listDir(fileNode.id, localPath, true);
           } else {
             files.push(fileNode);
           }


### PR DESCRIPTION
Remove the dependency to execSync. The biggest advantage this has, is that the output of aria is dumped directly to stdio and is not buffered through node, so you can see things like download speed and progress.
